### PR TITLE
fix Android 13 write permissions

### DIFF
--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -599,8 +599,11 @@ public class FileUtils extends CordovaPlugin {
     }
 
     private void getWritePermission(String rawArgs, int action, CallbackContext callbackContext) {
-        int requestCode = pendingRequests.createRequest(rawArgs, action, callbackContext);
+ int requestCode = pendingRequests.createRequest(rawArgs, action, callbackContext);
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+          } else {
         PermissionHelper.requestPermission(this, requestCode, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+          }
     }
 
     private boolean hasReadPermission() {
@@ -614,7 +617,11 @@ public class FileUtils extends CordovaPlugin {
     }
 
     private boolean hasWritePermission() {
-        return PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+          if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                return true;
+              } else {
+                return PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+              }
     }
 
     private boolean needPermission(String nativeURL, int permissionType) throws JSONException {


### PR DESCRIPTION
in Android 13 we don't need to ask for permissions

The assumption that we always have the permission is not always correct, but sufficient for our case where we don't try to write files owned by other apps
